### PR TITLE
Fix Shutter Rename issue when using Firefox browser

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -259,7 +259,7 @@ function inlineDefaultUpdateCell(cell, i, rowName, options) {
   cell.innerHTML = cellContent;
   if (i === 0) {
     // set the onsubmit function of the form of this row
-    document.getElementById(rowName+"Form").onsubmit = function () {
+    document.getElementById(rowName+"Form").onsubmit = function (event) {
       event.preventDefault();
       if (this.reportValidity()) {
         if (options.hasOwnProperty("finish"))


### PR DESCRIPTION
This commit should fix the issue when renaming Shutters in Firefox: "event" was not defined in the event-handler function parameters, therefore firefox couldn't process the onSubmit properly.