### PR TITLE
devcnt_handler without default value

### DIFF
--- a/Jarolift_MQTT.ino
+++ b/Jarolift_MQTT.ino
@@ -772,7 +772,7 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
 //####################################################################
 // increment and store devcnt, send devcnt as mqtt state topic
 //####################################################################
-void devcnt_handler(boolean do_increment = true) {
+void devcnt_handler(boolean do_increment) {
   if (do_increment)
     devcnt++;
   EEPROM.put(cntadr, devcnt);
@@ -885,7 +885,7 @@ void cmd_up(int channel) {
   rx_serial_array[2] = (new_serial >> 8) & 0xFF;
   rx_serial_array[3] = new_serial & 0xFF;
   mqtt_send_percent_closed_state(channel, 0, "UP");
-  devcnt_handler();
+  devcnt_handler(true);
 } // void cmd_up
 
 //####################################################################
@@ -911,7 +911,7 @@ void cmd_down(int channel) {
   rx_serial_array[2] = (new_serial >> 8) & 0xFF;
   rx_serial_array[3] = new_serial & 0xFF;
   mqtt_send_percent_closed_state(channel, 100, "DOWN");
-  devcnt_handler();
+  devcnt_handler(true);
 } // void cmd_down
 
 //####################################################################
@@ -937,7 +937,7 @@ void cmd_stop(int channel) {
   rx_serial_array[2] = (new_serial >> 8) & 0xFF;
   rx_serial_array[3] = new_serial & 0xFF;
   WriteLog("[INFO] - command STOP for channel "+ (String)channel+ " ("+ config.channel_name[channel]+ ") sent.", true);
-  devcnt_handler();
+  devcnt_handler(true);
 } // void cmd_stop
 
 //####################################################################
@@ -963,7 +963,7 @@ void cmd_shade(int channel) {
   rx_serial_array[2] = (new_serial >> 8) & 0xFF;
   rx_serial_array[3] = new_serial & 0xFF;
   mqtt_send_percent_closed_state(channel, 90, "SHADE");
-  devcnt_handler();
+  devcnt_handler(true);
 } // void cmd_shade
 
 //####################################################################


### PR DESCRIPTION
On Windows, I get error messages from the Arduino IDE:
`error: Default argument for parameter 1 of 'void devcnt_handler (boolean do_increment = true)`
Also by prototyping I do not succeed in solving this problem.
For the few occurrences, it makes sense to work without this default value.