### PR TITLE
delay in senden() is save

### DIFF
--- a/Jarolift_MQTT.ino
+++ b/Jarolift_MQTT.ino
@@ -498,10 +498,7 @@ void senden(int repetitions) {
     }
     group_h();                       // Last 8Bit. For motor 8-16.
 
-    unsigned long delaytime = micros(); // This part is necessary to prevent the wdt to reset the device.
-    delay(13);
-    delaytime = micros() - delaytime;
-    delayMicroseconds(16000 - delaytime);
+    delay(16);                       // delay in loop context is save for wdt
   }
 } // void senden
 


### PR DESCRIPTION
The function senden works in the context of loop, so a delay is safe from WDT. In contrast, the delayMicrosecons feature is not WDT save.
See the documentation of: [delayMicroseconds](https://arduino-esp8266.readthedocs.io/en/latest/reference.html?highlight=delayMicroseconds)