### PR TITLE
HTML Fix to save the parameters:

### DIFF
--- a/data/system.html
+++ b/data/system.html
@@ -221,8 +221,8 @@
 
                 <!-- Send button -->
                 <div class="siimple-form-field">
-                  <input type='button' class='siimple-btn siimple-btn--navy' value="save" onclick="writeConfig('save')">
-                  <input type='button' class='siimple-btn siimple-btn--grey' value="restart the dongle" onclick="writeConfig('restart')">
+                  <input type='button' class='siimple-btn siimple-btn--navy' value="save" name="save" onclick="writeConfig('save')">
+                  <input type='button' class='siimple-btn siimple-btn--grey' value="restart the dongle" name="restart" onclick="writeConfig('restart')">
                 </div>
               </div>
             </form>


### PR DESCRIPTION
Exception occured int the Webserver Parsing module by press the HTML button to save the settings in the admin mode.
Solution: Add a name to the button elements

headerValue: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
args: cmd=save&ssid=xxxxxxxxx&password=xxxxxxxxxxxxxxxxx&dhcp=true&ip_0=192&ip_1=168&ip_2=1&ip_3=100&nm_0=255&nm_1=255&nm_2=255&nm_3=0&gw_0=192&gw_1=168&gw_2=1&gw_3=1&mqtt_broker_addr_0=0&mqtt_broker_addr_1=0&mqtt_broker_addr_2=0&mqtt_broker_addr_3=0&mqtt_broker_port=1883&mqtt_broker_username=&mqtt_broker_password=&mqtt_broker_client_id=JaroliftDongle-005d981a&mqtt_devicetopic=jarolift&master_msb=0x12345678&master_lsb=0x12345678&learn_mode=true&serial=0x00bc61&set_and_generate_serial=false&devicecounter=65535&set_devicecounter=false&=save&=restart the dongle&

Soft WDT reset

>>>stack>>>

ctx: cont
sp: 3ffffb20 end: 3fffffc0 offset: 01b0
3ffffcd0:  3fff10cc 00000000 3ffffda8 4020f4b2
3ffffce0:  000001fe 00000204 3fff0e40 3ffffda8
3ffffcf0:  3fff0e40 0000020a 00000205 40100a28
3ffffd00:  00000220 3fff4070 00000001 3ffffda8
3ffffd10:  0000021f 3fff4070 3fff0e40 4020f5c0
3ffffd20:  3fff2114 00000001 4020f2e8 40214a64
3ffffd30:  0000021f 3fff0e68 3fff0e40 00000000
3ffffd40:  0000021f 3fff0e68 3ffffd60 00000000