### PR TITLE
Fix serial generating and parsing

### DIFF
--- a/global.h
+++ b/global.h
@@ -314,16 +314,18 @@ boolean ReadConfig()
   // if necessary, convert decimal to hexadecimal
   if ((config.serial[0] == '0') && (config.serial[1] == 'x')) {
     // config.serial is hex
-    // string serial stores only highest 3 bytes,
+    // Serial is 28 bits
+    // string serial stores only highest 24 bits,
     // add lowest byte with a shift operation for config.serial_number
-    config.serial_number = strtol(config.serial.c_str(), NULL, 16) << 8;
+    config.serial_number = strtol(config.serial.c_str(), NULL, 16) << 4;
   } else {
     // config.serial is NOT hex
     config.serial_number = strtol(config.serial.c_str(), NULL, 10);
-    // string serial stores only highest 3 bytes,
-    // remove lowest byte with a shift operation
+    // Serial is 28 bits.
+    // string serial stores only highest 24 bits,
+    // remove lowest 4 bits with a shift operation
     char serialNumBuffer[11];
-    snprintf(serialNumBuffer, 11, "0x%06x", (config.serial_number >> 8));
+    snprintf(serialNumBuffer, 11, "0x%06x", (config.serial_number >> 4));
     config.serial = serialNumBuffer;
     Serial.printf("convert config.serial to hex: %08u = 0x%08x \n", config.serial_number, config.serial_number);
     Serial.println("config.serial: " + config.serial);


### PR DESCRIPTION
Jarolift serials are 28bit values.
Currently, the serials are being generated from a 24bit input that is shifted by 8 bits. This causes the following problems:
- The 4 highest bits of the input are being ignored. Inputs `0x00BC61` and `0xF0BC61` will effectively send the same serials to the covers (although the values stored in the EEPROM will differ).
- It is impossible to 'copy' a remote if its serials do not end in `0x`, `x` being the increasing value `0` through `F`. e.g. A remote with channel 0 serial `0x0BC6110` can not be copied.

This PR corrects both problems by shifting the input value by 4 bits instead of 8. In the `cmd_` functions, we now use the actual serial from the EEPROM instead of the serials[] array to calculate the last byte used in the encrypted part of the final message as it has to include the last 4 bits of the input value.

The current serials are stored in the EEPROM in full, so this PR should not break current configurations until serials are regenerated with the same input. If serials must be regenerated after this patch, shift the input and add a `0`: `0x00BC61` becomes `0x0BC610`. The webui should reflect this change automatically.